### PR TITLE
Fix poem turning into "undefined"

### DIFF
--- a/poem.js
+++ b/poem.js
@@ -4,7 +4,7 @@ function nextLine(line) {
 "<p onClick=nextLine(2)>So many pull requests she did snub</p>",
 "<p onClick=nextLine(3)>So I forked the repo</p>",
 "<p onClick=nextLine(4)>Now they all send <em>me</em> changes, d'oh!</p>",
-"<p onClick=nextLine(5)>Said the maintainer, 'Welcome to the club!'</p>");
+"<p onClick=nextLine(0)>Said the maintainer, 'Welcome to the club!'</p>");
 
 	document.getElementById("line").innerHTML=poem[line];
 }


### PR DESCRIPTION
Before this change, after clicking on the poem a few times, it
would eventually show the word "undefined".

After this change, it loops back to the start of the poem, which
is the desired behavior suggested in #2.

Close #2
